### PR TITLE
Handle error when gem is behind a private repository

### DIFF
--- a/bin/bundler-integrity
+++ b/bin/bundler-integrity
@@ -85,6 +85,13 @@ deps.specs.each do |spec|
       end
     end
   end
+
+rescue RuntimeError => e
+  if /not found in the RubyGems API response/.match(e.message)
+    puts "\033[0;31m[FAILURE]\033[0m Checksum verification for #{full_name} failed! Maybe it is behind a private repository"
+  else
+    raise e
+  end
 end
 
 unless PRINT_EXPORT


### PR DESCRIPTION
Fix: https://github.com/diffend-io/bundler-integrity/issues/1

When gem is behind a private repo like

```ruby
source 'https://<MaciejRocks>@gem.fury.io/<company-name>/' do
  gem 'super-gem'
end
```

bundle-integrity was crashing:

```
bundler: failed to load command: bundler-integrity (/Users/benoit/.rbenv/versions/3.1.2/bin/bundler-integrity)
/Users/benoit/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-integrity-1.0.7/bin/bundler-integrity:54:in `block in <top (required)>':super-gem-4.4.1.gem not found in the RubyGems API response (RuntimeError)
	from /Users/benoit/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.11/lib/bundler/spec_set.rb:136:in `each'
	from /Users/benoit/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.11/lib/bundler/spec_set.rb:136:in `each'
	from /Users/benoit/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-integrity-1.0.7/bin/bundler-integrity:30:in `<top (required)>'
	from /Users/benoit/.rbenv/versions/3.1.2/bin/bundler-integrity:25:in `load'
	from /Users/benoit/.rbenv/versions/3.1.2/bin/bundler-integrity:25:in `<top (required)>'
	from /Users/benoit/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.11/lib/bundler/cli/exec.rb:58:in `load'
	from /Users/benoit/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.11/lib/bundler/cli/exec.rb:58:in `kernel_load'
	from /Users/benoit/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.11/lib/bundler/cli/exec.rb:23:in `run'
	from /Users/benoit/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.11/lib/bundler/cli.rb:483:in `exec'
	from /Users/benoit/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.11/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /Users/benoit/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.11/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/benoit/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.11/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /Users/benoit/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.11/lib/bundler/cli.rb:31:in `dispatch'
	from /Users/benoit/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.11/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /Users/benoit/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.11/lib/bundler/cli.rb:25:in `start'
	from /Users/benoit/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.11/exe/bundle:48:in `block in <top (required)>'
	from /Users/benoit/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.11/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
	from /Users/benoit/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.11/exe/bundle:36:in `<top (required)>'
	from /Users/benoit/.rbenv/versions/3.1.2/bin/bundle:25:in `load'
	from /Users/benoit/.rbenv/versions/3.1.2/bin/bundle:25:in `<main>'
```

The `spec.source.is_a?(Bundler::Source::Rubygems)` does not reflect that
we are in a private source scope. Inspecting object does not display any
information about the private repo source. Maybe it is a private API ? 
Maybe @deivid-rodriguez have an idea? :)

With this patch
![integrity-no-crash](https://user-images.githubusercontent.com/8417720/168035341-7b4a21af-ba5c-4416-9efe-68c9f54f35cf.jpg)

